### PR TITLE
Fixed typo

### DIFF
--- a/init.php
+++ b/init.php
@@ -184,7 +184,7 @@
     {
         $ch = curl_init();
         
-        $url = $article['link '];
+        $url = $article['link'];
         
         $api_endpoint = $this
             ->host


### PR DESCRIPTION
Extra space was preventing plugin from functioning properly. URL was not being passed to Mercury API.