### PR TITLE
修正 URL 编码问题与解析失败时属性不存在问题

### DIFF
--- a/init.php
+++ b/init.php
@@ -198,7 +198,7 @@ class mercury_fulltext extends Plugin
             ->host
             ->get($this, "mercury_API");
 
-        $ch = curl_init(rtrim($api_endpoint, '/') . '/parser?url=' . rawurlencode($link));
+        $ch = curl_init(rtrim($api_endpoint, '/') . '/parser?url=' . $this->process_link($link));
 
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 
@@ -283,5 +283,36 @@ class mercury_fulltext extends Plugin
         }
 
         print json_encode($result);
+    }
+
+    private function encode_uri($url)
+    {
+        // From: https://stackoverflow.com/a/6059053
+        // http://php.net/manual/en/function.rawurlencode.php
+        // https://developer.mozilla.org/en/JavaScript/Reference/Global_Objects/encodeURI
+        $unescaped = array(
+            '%2D'=>'-','%5F'=>'_','%2E'=>'.','%21'=>'!', '%7E'=>'~',
+            '%2A'=>'*', '%27'=>"'", '%28'=>'(', '%29'=>')'
+        );
+        $reserved = array(
+            '%3B'=>';','%2C'=>',','%2F'=>'/','%3F'=>'?','%3A'=>':',
+            '%40'=>'@','%26'=>'&','%3D'=>'=','%2B'=>'+','%24'=>'$'
+        );
+        $score = array(
+            '%23'=>'#'
+        );
+        return strtr(rawurlencode($url), array_merge($reserved,$unescaped,$score));
+    
+    }
+
+    private function process_link($url)
+    {
+        // Encode url when not encoded
+        // Characters defined in RFC 3986, Appendix A
+        if (!preg_match('/^[0-9a-zA-Z!#$%&\'()*+,\-.\/:;=?@\[\]_~]*$/', $url)) {
+            $url = $this->encode_uri($url);
+        }
+        
+        return rawurlencode($url);
     }
 }

--- a/init.php
+++ b/init.php
@@ -216,7 +216,7 @@ class mercury_fulltext extends Plugin
     {
         $output  = $this->send_request($article["link"]);
 
-        if ($output->content) {
+        if (property_exists($output, 'content') && $output->content) {
             $article["content"] = $output->content;
         }
 
@@ -278,7 +278,7 @@ class mercury_fulltext extends Plugin
         }
         $result=[];
 
-        if ($output->content) {
+        if (property_exists($output, 'content') && $output->content) {
             $result["content"] = $output->content;
         }
 


### PR DESCRIPTION
Mercury 要求传入的 URL 是已编码的，而拼接请求时 
URL 中还需要一次编码，也就是需要两次编码，而插件中仅进行了一次 `rawurlencode`。因此当遇到 DW 一类没有将链接中汉字进行编码的源就会导致 Mercury 无法正确发送请求。782cc61 中先检查 URL 字符是否符合 RFC 3986，若不符合则进行 URL 编码。

Mercury 当解析失败时返回数据中不存在 `content` 属性，因此直接访问 `$output->content` 会导致系统日志一直记录 Warning。70e4e49 加入了相关的检查。